### PR TITLE
Get metrics file path based on DRAGEN_results_dir

### DIFF
--- a/workflow/scripts/dragen_metrics_to_mqc.py
+++ b/workflow/scripts/dragen_metrics_to_mqc.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+
 samples_tsv = snakemake.input.samples_tsv
 
 duplication_out = snakemake.output.duplication
@@ -13,7 +14,7 @@ samples_df = pd.read_csv(samples_tsv, sep="\t", dtype=str)
 all_rows = []
 for _, row in samples_df.iterrows():
     sample = row["sample"]
-    metrics_path = row["metrics_tsv"]
+    metrics_path = f"{row["DRAGEN_results_dir"]}/{sample}.metrics.tsv"
 
     metrics_df = pd.read_csv(metrics_path, sep="\t", dtype=str)
     if metrics_df.empty:


### PR DESCRIPTION
Fixes a bug in the `workflow/scripts/dragen_metrics_to_mqc.py` script that I introduced when I changed the format of the `config/samples.tsv` file. 