### PR TITLE
Add 1000G AFs and ACs to sequence variants

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,6 +13,7 @@ genes:
 
 tools:
   cphi-dragen-anno: "~/CPHI-DRAGEN-anno/"
+  crg2_pacbio: "~/crg2-pacbio"
   annotSV: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-pacbio-non-conda-tools/AnnotSV-3.1.1"
   cre: "~/CPHI-DRAGEN-anno/workflow/scripts/cre"
   mity: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/crg2-non-conda-tools/mity_v2.0.1/bin"
@@ -39,6 +40,7 @@ annotation:
   general:
     exon: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/DRAGEN_genes/MANE/MANE.GRCh38.v1.5.ensembl_genomic.bed"
     ensembl: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/DRAGEN_genes/ensembl/Homo_sapiens.GRCh38.115.chr.processed.csv"
+    ensembl_to_NCBI_df: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/genes/ensembl/ensembl_to_NCBI_ID.csv"
     adotto_repeats: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/repeats/repeat_catalogs_for_TRGT/adotto_repeats.hg38.bed"
     clingen_path: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/ClinGen/"
   sv_report:

--- a/docs/pipeline_docs/compound_het_variant_annotation.md
+++ b/docs/pipeline_docs/compound_het_variant_annotation.md
@@ -1,0 +1,143 @@
+# Annotating compound heterozygous variants across variant types in short-read WGS
+
+Madeline Couse
+
+**Version 2026-04**
+
+## Changelog
+
+Adapted from the long-read [crg2-pacbio pipeline](https://github.com/ccmbioinfo/crg2-pacbio) for GRCh38 DRAGEN v4.4 short-read genomes. Note that variant phasing here will mostly rely on the availability of parental genotypes, as read-only variant phasing is only possible across very short distances with short-read WGS.
+
+## Variant filtering and preparation for phasing
+
+### Sequence variants
+
+For SNVs/indels, variants are first filtered by the gnomAD filtering allele frequency (less than 1%). We are interested in rare nonsynonymous variants as well as rare synonymous/noncoding (deep intronic, UTR) variants that may be damaging. So, when determining gene compound heterozygous (CH) status in the ‘wgs.coding’ report, we also consider rare genic synonymous/noncoding variants with the following filter:
+
+  - SpliceAI \>= 0.2 OR CADD \>= 10 OR abs(promoterAI) \>= 0.1 OR indel without CADD score (indels do not receive SpliceAI scores, and only common indels are scored by CADD)
+
+These synonymous/noncoding variants do not appear in the ‘wgs.coding’ report (unless they are in ClinVar) but are still considered in the CH status determination. Note that though variants that VEP has annotated as having the impact ‘intergenic\_variant’ are not considered in the CH status determination, those annotated as ‘upstream\_gene\_variant’ and ‘downstream\_gene\_variant’ are. VEP annotates variants within 5kb upstream or downstream as ‘upstream\_gene\_variant’ and ‘downstream\_gene\_variant’ respectively.
+
+Also note that if an SNV/indel overlaps multiple genes, the annotated gene is the gene with the higher impact. For example, if a variant is intronic in one gene and coding in the other, the variant will be annotated against the latter. If it is a tie between impact severities, the gene is effectively chosen randomly. These rules are imposed by the [gemini database](https://gemini.readthedocs.io/en/latest/index.html) we use to store and query variants.
+
+### SVs
+
+The SV report contains all SVs, so we work directly with the report. As with sequence variants, we do not consider intergenic variants in CH status determination, with the exception of those within 5kb upstream or downstream of a gene. We also exclude variants with \>1% filtering allele frequency in gnomAD.
+
+### CNVs
+
+Like SVs, we work directly with the CNV report. As with sequence variants, we do not consider intergenic variants in CH status determination, with the exception of those within 5kb upstream or downstream of a gene.
+
+## Determining CH status
+
+### CH status using proband-only short-read phasing
+
+With short-read sequencing, we can only phase variants in the same read or read-pair. 
+
+  - Consider only heterozygous variants in proband
+  - If there is only one variant in a gene, the CH status of the gene is ‘False’.
+  - If there are two or more variants in a gene, and neither is phased, the CH status of the gene is ‘Unknown’.
+  - If there are two or more phased variants in one gene belonging to the same phase block, and the variants are on different haplotypes (e.g. 1|0 and 0|1 genotypes), the CH status of the gene is ‘True’. If the variants are on the same haplotype (e.g. 1|0 and 1|0 genotypes), the CH status is ‘False’.
+  - If there are two or more variants in a gene belonging to more than one phase block, the CH status may be ‘True’ if there are at least two variants in trans in at least one phase block, or ‘Unknown’ otherwise (as we cannot know the relative phasing between different phase blocks).
+
+### CH status using parental genotypes
+
+  - Consider only heterozygous variants in proband where:
+    
+      - Neither parent is homozygous for the alternate allele
+    
+      - Both parents are not heterozygous
+  - If mother is heterozygous and father is reference, variant belongs to maternal haplotype
+  - If father is heterozygous and mother is reference, variant belongs to paternal haplotype
+  - If both parents are homozygous reference or one or both parent genotypes are missing, haplotype is unknown
+
+If there is at least one variant on the maternal haplotype and one variant on the paternal haplotype in a gene, the CH status of that gene is ‘True’.
+
+If there is at least one variant on a parental haplotype and at least one on an unknown haplotype, the CH status of the gene is ‘Unknown’.
+
+If there are multiple variants with unknown haplotype, the CH status of the gene is ‘Unknown’.
+
+### CH status determination: implementation
+
+CH algorithm inputs:
+
+  - A table of all medium and high impact variants in the family\*
+  - A table of all low impact variants in the family\*
+  - Family ‘wgs.coding’ report
+  - Family SV report
+  - Family CNV report
+  - A table with Ensembl, HGNC, and NCBI gene IDs
+  - Family pedigree file
+
+\* See documentation for variant impact classification [here](https://gemini.readthedocs.io/en/latest/content/database_schema.html#details-of-the-impact-and-impact-severity-columns).
+
+CH algorithm outputs:
+
+  - ‘wgs.coding’ report CSV with two additional columns, ‘CH\_variant\_types’ and ‘CH\_status’, that indicate if a gene contains at least one pair of heterozygous variants in *trans* in the proband, and what type of variants are in the gene.
+  - SV report CSV with two additional columns, ‘CH\_variant\_types’ and ‘CH\_status’, as above.
+  - CNV report CSV with two additional columns, ‘CH\_variant\_types’ and ‘CH\_status’, as above.
+  - A ‘\<family\>\_compound\_het\_variants’ CSV that comprises all sequence variants, SVs, and CNVs that are heterozygous in the proband, with gene CH status annotated (see Table 1). Sequence variants are annotated with gnomAD AF, CADD score, SpliceAI score, and ClinVar. Refer to this table to view CH status for all genes. If there is only one sequence variant in a gene that is annotated as CH in the ‘wgs.coding’ report, refer to this table to see additional variant(s) in the gene (e.g a deep intronic variant that would not be included in the ‘wgs.coding’ report). Note – SVs and CNVs that overlap multiple genes will be spread over multiple rows, with one gene per row.
+
+#### CH algorithm
+
+Sequence variant processing
+
+1.  Extract sequence variants from gemini db.
+
+2.  Filter low impact sequence variants\*:
+    
+    1.  Variant is not intergenic
+    
+    2.  SpliceAI \>= 0.2 OR CADD \>= 10 OR abs(promoterAI) \>= 0.1 OR indel without CADD score (indels do not receive SpliceAI scores, and only common indels are scored by CADD)
+
+3.  Index sequence variants by chromosome, position, ref allele, alt allele
+
+4.  Create a sequence variant table in long format with Ensembl gene ID and per-sample genotype information (genotype, zygosity, phase set ID).
+
+\*low impact variants present in ClinVar are exempt from these filters.
+
+SV processing
+
+5.  Index SVs by chromosome, start position, end position, SVTYPE, and pbsv SV ID.
+
+6.  Filter for high impact SVs: filter out intergenic SVs and SVs with a gnomAD allele frequency less than 1%.
+
+7.  Create an SV table in long format with Ensembl gene ID and per-sample genotype information (genotype, zygosity, phase set ID). Split variants by gene so that an SV that overlaps multiple genes is represented by multiple rows with one Ensembl gene ID per row.
+
+CNV processing
+
+8.  Repeat steps 5-7 for CNVs.
+
+9.  Concatenate sequence, SV, and CNV tables.
+
+CH status determination
+
+10. Identify genes with CH status in proband using only proband long-read phased genotypes and phase block IDs from the variant table created in step 9.
+
+11. For genes with unknown CH status after step 9, attempt to determine CH status using parental variant genotypes if available.
+
+12. Export proband heterozygous variants with CH gene annotations to a CSV in the format described in Table 1 below.
+
+Annotate variant reports with CH status
+
+13. Add per-gene CH status and variant type(s) to small variant reports, SV, and CNV reports as ‘CH\_variant\_types’ and ‘CH\_status’ columns. For SVs/CNVs overlapping multiple genes, the per-gene status and variant type(s) will be delimited by the ‘|’ symbol. If an SV is annotated as ‘intergenic\_variant’ by SnpEff, or is present in gnomAD at greater than 1% frequency, the CH\_status is ‘.’. Note that rare variants annotated against genes with an ‘upstream\_variant’ or ‘downstream\_variant’ impact ARE included in the CH status determination.
+
+| Column | Description | Example |
+| --- | --- | --- |
+| Variant_id | For sequence variants: chr-pos-ref-alt<br>For SVs: chr-start-end-SVTYPE-SVID<br>For CNVs: chr-start-end-SVTYPE | 15-48781193-T-C |
+| Variant_type | One of: sequence_variant, SV, CNV | sequence_variant |
+| Gene_name | HGNC gene symbol | CEP152 |
+| Ensembl_gene_id | Ensembl gene ID | ENSG00000103995 |
+| CH_status | Compound heterozygous status:<br>TRUE if there are at least two variants in the gene in *trans*<br>FALSE if there is only one variant in the gene, or all variants are in *cis*<br>UNKNOWN if there are at least two variants in a gene but phase cannot be determined (e.g. parental data is not available, and the variants reside in different phase blocks in the gene) | TRUE |
+| `Zygosity_<sample>` | Variant zygosity for this particular sample. | het |
+| Variation | Most severe impact of sequence variant. Only available for sequence variants in this table. | stop_gained |
+| Clinvar | Clinvar pathogenic status. Only available for sequence variants in this table. | Pathogenic |
+| Gnomad_af_grpmax | Maximum allele frequency across genetic ancestry groups in joint (WES and WGS) dataset. Only available for sequence variants in this table. | 0.000946139974985 |
+| Cadd_score | CADD score. Only available for sequence variants in this table. | 27.9 |
+| SpliceAI_score | SpliceAI score. Only available for sequence variants in this table. | C\|CEP152\|0.00\|0.00\|0.00\|0.00\|-1\|-7\|16\|-7 |
+| promoterAI_score | promoterAI score. Only available for sequence variants in this table. | . |
+| Nucleotide_change_ensembl | Ensembl HGVS. Only available for sequence variants in this table. | ENST00000325747.9:c.1755T\>G |
+| `GT_abstracted_<sample>` | Genotype for phased variants is represented as ‘ref\|alt’ or ‘alt\|ref’ to facilitate a quick visual check for compound heterozygosity. For unphased variants, genotypes are left as is (e.g. T/A). | ref\|alt |
+| `PS_<sample>` | Phase set ID. Note that this will be missing for the majority of variants called from short-read sequencing data. Variants that belong to the same phase block (ie have the same PS ID) have phased genotypes that can be interpreted relative to one another. So, variants with genotypes of ‘ref\|alt’ and ‘alt\|ref’ are in *trans*, while variants with genotypes of ‘ref\|alt’ and ‘ref\|alt’ are in *cis*. If variants reside in different phase blocks, phased genotypes *cannot* be interpreted relative to one another. | 48686679 |
+
+Table 1. Family compound heterozygosity table.

--- a/docs/variant_report_docs/DRAGEN_sequence_variant_report.md
+++ b/docs/variant_report_docs/DRAGEN_sequence_variant_report.md
@@ -68,6 +68,18 @@ Non-coding prediction scores thresholds above which we consider a variant to be 
 
 Thresholds taken from table 3\* in <https://doi.org/10.1016/j.gpb.2022.02.002>, with the exception of CADD; the study used v1.3, and we use v1.7. We chose the CADD threshold based on [this paper](https://doi.org/10.1093/nargab/lqaf157).
 
+### 1.3 1000 Genomes allele frequencies and counts
+
+The 1000 Genomes sequence variant database (n=3,102, 602 trios) used to annotate variants was created from [DRAGEN SV callsets v4.4.7](https://registry.opendata.aws/ilmn-dragen-1kgp/) using the following methods:
+
+  - Download per-sample DRAGEN SV VCFs from the public 1000 Genomes DRAGEN S3 bucket
+  - Run `bcftools norm` and `vt decompose` to left-normalize and decompose multiallelic variants. 
+  - Retain only `FILTER=PASS` variants and remove all format fields
+  - Merge single-sample VCFs into one cohort-level VCF
+  - Use `bcftools +fill-tags` to populate cohort INFO tags: `AC, AC_Hom, AC_Het, AN, AF`
+  - Recalculate `AF` from `AC` using a fixed cohort size of 3102 samples (`AN = 6204`).
+  - Derive `NHOMALT` from `AC_Hom / 2`.
+
 ## 2\. Column descriptions
 
 | **Column_id** | **Comment** | **Source** | **Example** |
@@ -108,6 +120,9 @@ Thresholds taken from table 3\* in <https://doi.org/10.1016/j.gpb.2022.02.002>, 
 | `Gnomad_filter` | VCF filter status (e.g. BOTH_FILTERED / EXOMES_FILTERED / GENOMES_FILTERED) | gnomAD v4.1.1 | EXOMES_FILTERED |
 | `Regeneron_exome_AF` | Allele frequency in Regeneron million exomes | [Regeneron](https://rgc-research.regeneron.com/me/resources) | 0.000152189997607 |
 | `Regeneron_exome_AC` | Allele count in Regeneron million exomes | [Regeneron](https://rgc-research.regeneron.com/me/resources) | 25 |
+| `thousandG_AF` | Allele frequency in 1000 Genomes DRAGEN v4.4 genomes (n=3,102, 602 trios) | [1000 Genomes](https://registry.opendata.aws/ilmn-dragen-1kgp/) | 0.0002 |
+| `thousandG_AC` | Allele count in 1000 Genomes DRAGEN v4.4 genomes (n=3,102, 602 trios) | [1000 Genomes](https://registry.opendata.aws/ilmn-dragen-1kgp/) | 2 |
+| `thousandG_nhomalt` | Homozygous alternate count in 1000 Genomes DRAGEN v4.4 genomes (n=3,102, 602 trios) | [1000 Genomes](https://registry.opendata.aws/ilmn-dragen-1kgp/) | 0 |
 | `Ensembl_transcript_id` | Most severely affected transcript | VEP | ENST00000374632 |
 | `rsIDs` | Variant IDs (dbSNP) | VEP | rs28936395 |
 | `AA_position` | Amino-acid position for most severely-affected transcript | VEP | 679/987 |

--- a/resources/vcfanno/vcfanno.conf
+++ b/resources/vcfanno/vcfanno.conf
@@ -12,6 +12,12 @@ names=["regeneron_exome_AC", "regeneron_exome_AF"]
 ops=["self","self"]
 
 [[annotation]]
+file="1000G_hardfiltered_merged.PASS.GTonly.sorted.tags.sites.recalc.decomp.uniq.vcf.gz"
+fields=["AC", "AF", "NHOMALT"]
+names=["thousandG_AC", "thousandG_AF", "thousandG_nhomalt"]
+ops=["self","self","self"]
+
+[[annotation]]
 file="dbsnp-151.vcf.gz"
 fields=["ID"]
 names=["rs_ids"]

--- a/slurm-profile/config.v8+.yaml
+++ b/slurm-profile/config.v8+.yaml
@@ -59,5 +59,5 @@ default-resources:
 # Rule specific resources
 # ---------------------------------------------------------------------------
 set-resources:
-    myrule:
-        mem: 500MB
+    vcf2db:
+        runtime: "60h"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -29,6 +29,7 @@ include: "rules/cnvreport.smk"
 include: "rules/annotate_sequence_var.smk"
 include: "rules/annotate_mt_var.smk"
 include: "rules/qc.smk"
+include: "rules/compound_hets.smk"
 
 
 family = config["run"]["family"]
@@ -36,13 +37,14 @@ samples = pd.read_table(config["run"]["samples"], dtype=str).set_index("sample",
 
 rule all:
     input:
-        "sequence_variants/coding/{family}".format(family=family),
-        "sequence_variants/panel/{family}".format(family=family),
-        "sequence_variants/panel-flank/{family}".format(family=family),
-        "sequence_variants/wgs-high-impact/{family}".format(family=family),
-        "sequence_variants/denovo/{family}".format(family=family) if len(children) > 0 else [],
+        "reports/{family}.wgs.coding.CH.csv".format(family=family),
+        "reports/{family}.panel.CH.csv".format(family=family),
+        "reports/{family}.panel-flank.CH.csv".format(family=family),
+        "reports/{family}.wgs.high.impact.CH.csv".format(family=family),
+        "reports/{family}.wgs.denovo.csv".format(family=family) if len(children) > 0 else [],
         "reports/{family}.known.path.str.loci.csv".format(family=family),
-        "reports/{family}.sv.csv".format(family=family),
-        "reports/{family}.cnv.csv".format(family=family),
+        "reports/{family}.sv.CH.csv".format(family=family),
+        "reports/{family}.cnv.CH.csv".format(family=family),
         "reports/{family}.mito.csv".format(family=family),
-        "reports/{family}.multiqc_report.html".format(family=family)
+        "reports/{family}.multiqc_report.html".format(family=family),
+        "reports/{family}.compound.het.status.CH.csv".format(family=family)

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -41,7 +41,7 @@ rule all:
         "reports/{family}.panel.CH.csv".format(family=family),
         "reports/{family}.panel-flank.CH.csv".format(family=family),
         "reports/{family}.wgs.high.impact.CH.csv".format(family=family),
-        "reports/{family}.wgs.denovo.csv".format(family=family) if len(children) > 0 else [],
+        "reports/{family}.wgs.denovo.CH.csv".format(family=family) if len(children) > 0 else [],
         "reports/{family}.known.path.str.loci.csv".format(family=family),
         "reports/{family}.sv.CH.csv".format(family=family),
         "reports/{family}.cnv.CH.csv".format(family=family),

--- a/workflow/envs/gemini.yaml
+++ b/workflow/envs/gemini.yaml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - gemini =0.20.1
+  - numpy =1.15.4
+  - python =2.7.15

--- a/workflow/rules/annotate_sequence_var.smk
+++ b/workflow/rules/annotate_sequence_var.smk
@@ -72,7 +72,7 @@ rule vcfanno:
     input:
         "annotated/{p}/vep/{family}.{p}.vep.vcf",
     output:
-        "annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.vcf.gz",
+        "annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.no.PS.vcf.gz",
     log:
         "logs/vcfanno/{family}.vcfanno.{p}.log"
     threads: 10
@@ -84,6 +84,34 @@ rule vcfanno:
         base_path=config["annotation"]["vcfanno"]["base_path"],
     wrapper:
         get_wrapper_path("vcfanno")
+
+rule add_ps_field:
+    input:
+       vcf="annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.no.PS.vcf.gz",
+    output:
+        temp("annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.vcf"),
+    log:
+        "logs/bcftools/{family}.add.PS.field.{p}.log"
+    conda: 
+        "../envs/common.yaml"
+    shell:
+        '''
+            #Get the PS values for every sample from the FORMAT VCF field, remove the trailing comma and store the results in PS_annot.txt
+            bcftools query -f '%CHROM\t%POS\t[%PS,]\n' {input.vcf} | sed 's/,*$//g' > annotated/{wildcards.p}/vcfanno/PS_annot.txt
+
+            #BGZIP and TABIX the PS_annot.txt file
+            bgzip annotated/{wildcards.p}/vcfanno/PS_annot.txt
+            tabix -s1 -b2 -e2 annotated/{wildcards.p}/vcfanno/PS_annot.txt.gz
+
+            #create header file containing PS INFO field info
+            echo -e "##INFO=<ID=PS,Number=.,Type=String,Description="Phase set">" > annotated/{wildcards.p}/vcfanno/hdr.txt
+
+            #Annotate the VCF with the PS_annot.txt.gz file to add PS tag info to the VCF
+            bcftools annotate -a annotated/{wildcards.p}/vcfanno/PS_annot.txt.gz -h annotated/{wildcards.p}/vcfanno/hdr.txt -c CHROM,POS,INFO/PS {input.vcf} > {output}
+
+            #Remove intermediate files  
+            rm annotated/{wildcards.p}/vcfanno/PS_annot.txt.gz annotated/{wildcards.p}/vcfanno/PS_annot.txt.gz.tbi annotated/{wildcards.p}/vcfanno/hdr.txt
+        '''
 
 rule vcf2db:
     input:
@@ -103,8 +131,8 @@ rule bgzip:
        "{prefix}.vcf"
    output:
        "{prefix}.vcf.gz"
-   wildcard_constraints:
-       prefix = "(?!.*panel).*"
+#    wildcard_constraints:
+#        prefix = "(?!.*panel).*"
    conda:
        "../envs/common.yaml"
    shell:

--- a/workflow/rules/compound_hets.smk
+++ b/workflow/rules/compound_hets.smk
@@ -1,0 +1,78 @@
+rule get_sequence_variants_for_CH:
+    input:
+        gemini_db="annotated/coding/{family}-gemini.db"
+    output:
+        variants="sequence_variants/{family}.{severity}.impact.variants.tsv",
+    params:
+        severity="{severity}",
+        crg2_pacbio = config["tools"]["crg2_pacbio"],
+        seq_type="short"
+    log:
+        "logs/compound_hets/{family}.get.sequence.variants.for.CH.{severity}.log",
+    conda:
+        "../envs/gemini.yaml"
+    wildcard_constraints:
+        severity="HIGH-MED|LOW"
+    shell:
+        "{params.crg2_pacbio}/scripts/compound_hets/get_sequence_var_for_CH.sh {input.gemini_db} {params.severity} {params.seq_type} > {output.variants}"
+
+rule get_VCF_sample_order:
+    input:
+        vcf="annotated/coding/vcfanno/{family}.coding.vep.vcfanno.vcf.gz",
+    output:
+        sample_order="sequence_variants/{family}.sample.order.txt",
+    log:
+        "logs/compound_hets/{family}.get.VCF.sample.order.log",
+    conda:
+        "../envs/common.yaml"
+    shell:
+        "bcftools query -l {input.vcf} > {output.sample_order}"
+
+rule identify_compound_hets:
+    input:
+        high_med_variants="sequence_variants/{family}.HIGH-MED.impact.variants.tsv",
+        low_variants="sequence_variants/{family}.LOW.impact.variants.tsv",
+        small_variant_report_dir="sequence_variants/coding/{family}",
+        panel_variant_report_dir="sequence_variants/panel/{family}",
+        panel_flank_variant_report_dir="sequence_variants/panel-flank/{family}",
+        wgs_high_impact_variant_report_dir="sequence_variants/wgs-high-impact/{family}",
+        SV_report="reports/{family}.sv.csv",
+        CNV_report="reports/{family}.cnv.csv",
+        ensembl=config["annotation"]["general"]["ensembl"],
+        ensembl_to_NCBI_df=config["annotation"]["general"]["ensembl_to_NCBI_df"],
+        HPO=config["run"]["hpo"],
+        pedigree=config["run"]["ped"],
+        sample_order="sequence_variants/{family}.sample.order.txt",
+    output:
+        sequence_variant_report_CH="reports/{family}.wgs.coding.CH.csv",
+        panel_variant_report_CH="reports/{family}.panel.CH.csv",
+        panel_flank_variant_report_CH="reports/{family}.panel-flank.CH.csv",
+        wgs_high_impact_variant_report_CH="reports/{family}.wgs.high.impact.CH.csv",
+        SV_report_CH="reports/{family}.sv.CH.csv",
+        CNV_report_CH="reports/{family}.cnv.CH.csv",
+        compound_het_status="reports/{family}.compound.het.status.CH.csv",
+    params:
+        crg2_pacbio = config["tools"]["crg2_pacbio"],
+        seq_type="short"
+    conda:
+        "../envs/str_sv.yaml"
+    log:
+        "logs/compound_hets/{family}.identify.compound.hets.log",
+    shell:
+        """
+        (python3 {params.crg2_pacbio}/scripts/annotate_compound_hets.py --seq_type {params.seq_type} --high_med {input.high_med_variants} \
+        --low {input.low_variants} \
+        --sv {input.SV_report}  \
+        --cnv {input.CNV_report}  \
+        --ensembl {input.ensembl}  \
+        --ensembl_to_NCBI_df {input.ensembl_to_NCBI_df}  \
+        --pedigree {input.pedigree}  \
+        --hpo {input.HPO}  \
+        --sequence_variant_report_dir {input.small_variant_report_dir}  \
+        --panel_variant_report_dir {input.panel_variant_report_dir}  \
+        --panel_flank_variant_report_dir {input.panel_flank_variant_report_dir}  \
+        --wgs_high_impact_variant_report_dir {input.wgs_high_impact_variant_report_dir}  \
+        --sample_order {input.sample_order}  \
+        --family {wildcards.family}) > {log} 2>&1
+        """
+ 

--- a/workflow/rules/compound_hets.smk
+++ b/workflow/rules/compound_hets.smk
@@ -28,51 +28,103 @@ rule get_VCF_sample_order:
     shell:
         "bcftools query -l {input.vcf} > {output.sample_order}"
 
-rule identify_compound_hets:
-    input:
-        high_med_variants="sequence_variants/{family}.HIGH-MED.impact.variants.tsv",
-        low_variants="sequence_variants/{family}.LOW.impact.variants.tsv",
-        small_variant_report_dir="sequence_variants/coding/{family}",
-        panel_variant_report_dir="sequence_variants/panel/{family}",
-        panel_flank_variant_report_dir="sequence_variants/panel-flank/{family}",
-        wgs_high_impact_variant_report_dir="sequence_variants/wgs-high-impact/{family}",
-        SV_report="reports/{family}.sv.csv",
-        CNV_report="reports/{family}.cnv.csv",
-        ensembl=config["annotation"]["general"]["ensembl"],
-        ensembl_to_NCBI_df=config["annotation"]["general"]["ensembl_to_NCBI_df"],
-        HPO=config["run"]["hpo"],
-        pedigree=config["run"]["ped"],
-        sample_order="sequence_variants/{family}.sample.order.txt",
-    output:
-        sequence_variant_report_CH="reports/{family}.wgs.coding.CH.csv",
-        panel_variant_report_CH="reports/{family}.panel.CH.csv",
-        panel_flank_variant_report_CH="reports/{family}.panel-flank.CH.csv",
-        wgs_high_impact_variant_report_CH="reports/{family}.wgs.high.impact.CH.csv",
-        SV_report_CH="reports/{family}.sv.CH.csv",
-        CNV_report_CH="reports/{family}.cnv.CH.csv",
-        compound_het_status="reports/{family}.compound.het.status.CH.csv",
-    params:
-        crg2_pacbio = config["tools"]["crg2_pacbio"],
-        seq_type="short"
-    conda:
-        "../envs/str_sv.yaml"
-    log:
-        "logs/compound_hets/{family}.identify.compound.hets.log",
-    shell:
-        """
-        (python3 {params.crg2_pacbio}/scripts/annotate_compound_hets.py --seq_type {params.seq_type} --high_med {input.high_med_variants} \
-        --low {input.low_variants} \
-        --sv {input.SV_report}  \
-        --cnv {input.CNV_report}  \
-        --ensembl {input.ensembl}  \
-        --ensembl_to_NCBI_df {input.ensembl_to_NCBI_df}  \
-        --pedigree {input.pedigree}  \
-        --hpo {input.HPO}  \
-        --sequence_variant_report_dir {input.small_variant_report_dir}  \
-        --panel_variant_report_dir {input.panel_variant_report_dir}  \
-        --panel_flank_variant_report_dir {input.panel_flank_variant_report_dir}  \
-        --wgs_high_impact_variant_report_dir {input.wgs_high_impact_variant_report_dir}  \
-        --sample_order {input.sample_order}  \
-        --family {wildcards.family}) > {log} 2>&1
-        """
+if len(children) > 0:
+    rule identify_compound_hets_with_denovo:
+        input:
+            high_med_variants="sequence_variants/{family}.HIGH-MED.impact.variants.tsv",
+            low_variants="sequence_variants/{family}.LOW.impact.variants.tsv",
+            small_variant_report_dir="sequence_variants/coding/{family}",
+            panel_variant_report_dir="sequence_variants/panel/{family}",
+            panel_flank_variant_report_dir="sequence_variants/panel-flank/{family}",
+            wgs_high_impact_variant_report_dir="sequence_variants/wgs-high-impact/{family}",
+            wgs_denovo_variant_report_dir="sequence_variants/denovo/{family}",
+            SV_report="reports/{family}.sv.csv",
+            CNV_report="reports/{family}.cnv.csv",
+            ensembl=config["annotation"]["general"]["ensembl"],
+            ensembl_to_NCBI_df=config["annotation"]["general"]["ensembl_to_NCBI_df"],
+            HPO=config["run"]["hpo"],
+            pedigree=config["run"]["ped"],
+            sample_order="sequence_variants/{family}.sample.order.txt",
+        output:
+            sequence_variant_report_CH="reports/{family}.wgs.coding.CH.csv",
+            panel_variant_report_CH="reports/{family}.panel.CH.csv",
+            panel_flank_variant_report_CH="reports/{family}.panel-flank.CH.csv",
+            wgs_high_impact_variant_report_CH="reports/{family}.wgs.high.impact.CH.csv",
+            wgs_denovo_variant_report_CH="reports/{family}.wgs.denovo.CH.csv",
+            SV_report_CH="reports/{family}.sv.CH.csv",
+            CNV_report_CH="reports/{family}.cnv.CH.csv",
+            compound_het_status="reports/{family}.compound.het.status.CH.csv",
+        params:
+            crg2_pacbio = config["tools"]["crg2_pacbio"],
+            seq_type="short"
+        conda:
+            "../envs/str_sv.yaml"
+        log:
+            "logs/compound_hets/{family}.identify.compound.hets.log",
+        shell:
+            """
+            (python3 {params.crg2_pacbio}/scripts/annotate_compound_hets.py --seq_type {params.seq_type} --high_med {input.high_med_variants} \
+            --low {input.low_variants} \
+            --sv {input.SV_report}  \
+            --cnv {input.CNV_report}  \
+            --ensembl {input.ensembl}  \
+            --ensembl_to_NCBI_df {input.ensembl_to_NCBI_df}  \
+            --pedigree {input.pedigree}  \
+            --hpo {input.HPO}  \
+            --sequence_variant_report_dir {input.small_variant_report_dir}  \
+            --panel_variant_report_dir {input.panel_variant_report_dir}  \
+            --panel_flank_variant_report_dir {input.panel_flank_variant_report_dir}  \
+            --wgs_high_impact_variant_report_dir {input.wgs_high_impact_variant_report_dir}  \
+            --wgs_denovo_variant_report_dir {input.wgs_denovo_variant_report_dir}  \
+            --sample_order {input.sample_order}  \
+            --family {wildcards.family}) > {log} 2>&1
+            """
+else:
+        rule identify_compound_hets:
+            input:
+                high_med_variants="sequence_variants/{family}.HIGH-MED.impact.variants.tsv",
+                low_variants="sequence_variants/{family}.LOW.impact.variants.tsv",
+                small_variant_report_dir="sequence_variants/coding/{family}",
+                panel_variant_report_dir="sequence_variants/panel/{family}",
+                panel_flank_variant_report_dir="sequence_variants/panel-flank/{family}",
+                wgs_high_impact_variant_report_dir="sequence_variants/wgs-high-impact/{family}",
+                SV_report="reports/{family}.sv.csv",
+                CNV_report="reports/{family}.cnv.csv",
+                ensembl=config["annotation"]["general"]["ensembl"],
+                ensembl_to_NCBI_df=config["annotation"]["general"]["ensembl_to_NCBI_df"],
+                HPO=config["run"]["hpo"],
+                pedigree=config["run"]["ped"],
+                sample_order="sequence_variants/{family}.sample.order.txt",
+            output:
+                sequence_variant_report_CH="reports/{family}.wgs.coding.CH.csv",
+                panel_variant_report_CH="reports/{family}.panel.CH.csv",
+                panel_flank_variant_report_CH="reports/{family}.panel-flank.CH.csv",
+                wgs_high_impact_variant_report_CH="reports/{family}.wgs.high.impact.CH.csv",
+                SV_report_CH="reports/{family}.sv.CH.csv",
+                CNV_report_CH="reports/{family}.cnv.CH.csv",
+                compound_het_status="reports/{family}.compound.het.status.CH.csv",
+            params:
+                crg2_pacbio = config["tools"]["crg2_pacbio"],
+                seq_type="short"
+            conda:
+                "../envs/str_sv.yaml"
+            log:
+                "logs/compound_hets/{family}.identify.compound.hets.log",
+            shell:
+                """
+                (python3 {params.crg2_pacbio}/scripts/annotate_compound_hets.py --seq_type {params.seq_type} --high_med {input.high_med_variants} \
+                --low {input.low_variants} \
+                --sv {input.SV_report}  \
+                --cnv {input.CNV_report}  \
+                --ensembl {input.ensembl}  \
+                --ensembl_to_NCBI_df {input.ensembl_to_NCBI_df}  \
+                --pedigree {input.pedigree}  \
+                --hpo {input.HPO}  \
+                --sequence_variant_report_dir {input.small_variant_report_dir}  \
+                --panel_variant_report_dir {input.panel_variant_report_dir}  \
+                --panel_flank_variant_report_dir {input.panel_flank_variant_report_dir}  \
+                --wgs_high_impact_variant_report_dir {input.wgs_high_impact_variant_report_dir}  \
+                --sample_order {input.sample_order}  \
+                --family {wildcards.family}) > {log} 2>&1
+                """
  

--- a/workflow/scripts/cre/cre.gemini2txt.vcf2db.sh
+++ b/workflow/scripts/cre/cre.gemini2txt.vcf2db.sh
@@ -85,6 +85,9 @@ sQuery="select \
         gnomad_filter as Gnomad_filter, \
         regeneron_exome_AF as Regeneron_exome_AF, \
         regeneron_exome_AC as Regeneron_exome_AC, \
+        thousandG_ac as thousandG_AC,\
+        thousandG_af as thousandG_AF,\
+        thousandG_nhomalt as thousandG_nhomalt,\
         sift_score as Sift_score,\
         polyphen_score as Polyphen_score,\
         cadd_phred as Cadd_score,\

--- a/workflow/scripts/cre/cre.vcf2db.R
+++ b/workflow/scripts/cre/cre.vcf2db.R
@@ -476,7 +476,7 @@ create_report <- function(family, samples, type){
     # Column 57: ENH_cellline_tissue
 
     # replace -1 with 0
-    for (field in c("Trio_coverage", "Gnomad_af", "Gnomad_af_grpmax", "Gnomad_fafmax_faf95_max", "Regeneron_exome_AF", "Regeneron_exome_AC")){
+    for (field in c("Trio_coverage", "Gnomad_af", "Gnomad_af_grpmax", "Gnomad_fafmax_faf95_max", "Regeneron_exome_AF", "Regeneron_exome_AC", "thousandG_AF", "thousandG_AC", "thousandG_nhomalt")){
         variants[,field] <- with(variants, gsub("-1", "0", get(field), fixed = T))
         variants[,field] <- with(variants, gsub("None", "0", get(field), fixed = T))
     }
@@ -519,6 +519,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
                             "HGMD_id", "HGMD_gene", "HGMD_tag", "HGMD_ref",
                             "Gnomad_af_grpmax", "Gnomad_af", "Gnomad_ac", "Gnomad_hom", "Gnomad_male_ac","Gnomad_fafmax_faf95_max", "Gnomad_filter",
                             "Regeneron_exome_AF", "Regeneron_exome_AC",
+                            "thousandG_AF", "thousandG_AC", "thousandG_nhomalt",
                             "Ensembl_transcript_id", "rsIDs"),
                             protein_cols,
                             c("Gnomad_oe_lof_score", "Gnomad_oe_ci_lower","Gnomad_oe_ci_upper","Gnomad_oe_mis_score", "Gnomad_mis_z_score","Gnomad_pLI_score","Gnomad_pnull_score","Gnomad_prec_score"),


### PR DESCRIPTION
@rohan-ah-khan generated a 1000 Genomes sequence variant database (n=3,102, 602 trios) from [DRAGEN SV callsets v4.4.7](https://registry.opendata.aws/ilmn-dragen-1kgp/) using the following methods:

  - Download per-sample DRAGEN SV VCFs from the public 1000 Genomes DRAGEN S3 bucket
  - Run `bcftools norm` and `vt decompose` to left-normalize and decompose multiallelic variants. 
  - Retain only `FILTER=PASS` variants and remove all format fields
  - Merge single-sample VCFs into one cohort-level VCF
  - Use `bcftools +fill-tags` to populate cohort INFO tags: `AC, AC_Hom, AC_Het, AN, AF`
  - Recalculate `AF` from `AC` using a fixed cohort size of 3102 samples (`AN = 6204`).
  - Derive `NHOMALT` from `AC_Hom / 2`.