### PR TITLE
Fix NA handling in add_hpo function

### DIFF
--- a/workflow/scripts/annotate_SVs.py
+++ b/workflow/scripts/annotate_SVs.py
@@ -410,6 +410,14 @@ def annotate_pop_svs(annotsv_df, pop_svs, cols, variant_type):
             lambda x: max([float(af) for af in x.split("; ")])
         )
         cols.append(f"{pop_name}_maxAF")
+        hom_cols = [col for col in cols if "HOM" in col or "nhomalt" in col]
+        if len(hom_cols) > 0:
+            hom_col = hom_cols[0]
+            intersect[f"{hom_col}_max"] = intersect[hom_col].apply(
+                lambda x: max([float(hom) for hom in x.split("; ")])
+            )
+            cols.append(f"{hom_col}_max")
+
     # get max allele counts for C4R
     except IndexError:
         try:
@@ -1034,7 +1042,7 @@ def main(
             add_hpo(hpo, gene) for gene in df_merge["ENSEMBL_GENE"].values
         ]
     except:
-         print("No HPO terms")
+        print("No HPO terms")
 
     # add OMIM phenos and inheritance by gene matching
     print("Preparing OMIM data")
@@ -1197,6 +1205,7 @@ def main(
     )
 
     df_merge = df_merge[report_columns]
+    df_merge.rename(columns={"gnomad_HOM": "gnomad_nhomalt", "gnomad_HOM_max": "gnomad_nhomalt_max"}, inplace=True)
     if variant_type == "CNV":
         # exclude splice site annotations for CNVs
         df_merge = df_merge.drop(columns=["Nearest_SS_type", "Dist_nearest_SS", "ID"] + pr_alt_cols + sr_alt_cols + vf_alt_cols + gq_cols + fs_cols)

--- a/workflow/scripts/annotate_SVs.py
+++ b/workflow/scripts/annotate_SVs.py
@@ -151,10 +151,12 @@ def merge_full_split_annos(annotsv_df):
 
 
 def add_hpo(hpo, gene):
+    if pd.isna(gene):
+        return "."
     try:
         genes = [g for g in re.split('[;&]', gene) if g]
     except AttributeError:
-        return "NA"
+        return "."
     terms = []
     for gene in genes:
         # split by - for intergenic variants, which are annotated as <upstream_gene>-<downstream_gene>
@@ -180,8 +182,6 @@ def add_omim(omim_df, gene):
     try:
         genes = [g for g in re.split('[;&]', gene) if g]
     except TypeError:
-        print("Omim")
-        print(gene)
         return [".","."]
     phenos = []
     inheritance = []
@@ -410,14 +410,6 @@ def annotate_pop_svs(annotsv_df, pop_svs, cols, variant_type):
             lambda x: max([float(af) for af in x.split("; ")])
         )
         cols.append(f"{pop_name}_maxAF")
-        hom_cols = [col for col in cols if "HOM" in col or "nhomalt" in col]
-        if len(hom_cols) > 0:
-            hom_col = hom_cols[0]
-            intersect[f"{hom_col}_max"] = intersect[hom_col].apply(
-                lambda x: max([float(hom) for hom in x.split("; ")])
-            )
-            cols.append(f"{hom_col}_max")
-
     # get max allele counts for C4R
     except IndexError:
         try:
@@ -737,8 +729,6 @@ def add_clingen(clingen_df, gene, colname):
     try:
         genes = [g for g in re.split('[;&]', gene) if g]
     except TypeError:
-        print("ClinGen")
-        print(gene)
         return "NA"
     clingen = []
     for gene in genes:
@@ -1044,7 +1034,7 @@ def main(
             add_hpo(hpo, gene) for gene in df_merge["ENSEMBL_GENE"].values
         ]
     except:
-        print("No HPO terms")
+         print("No HPO terms")
 
     # add OMIM phenos and inheritance by gene matching
     print("Preparing OMIM data")
@@ -1207,7 +1197,6 @@ def main(
     )
 
     df_merge = df_merge[report_columns]
-    df_merge.rename(columns={"gnomad_HOM": "gnomad_nhomalt", "gnomad_HOM_max": "gnomad_nhomalt_max"}, inplace=True)
     if variant_type == "CNV":
         # exclude splice site annotations for CNVs
         df_merge = df_merge.drop(columns=["Nearest_SS_type", "Dist_nearest_SS", "ID"] + pr_alt_cols + sr_alt_cols + vf_alt_cols + gq_cols + fs_cols)


### PR DESCRIPTION
This PR fixes a bug where NA values in the Ensembl gene column introduced a TypeError that was not properly handled by the add_hpo function, resulting in SVs not being annotated against supplied HPO terms. Instead, I added logic to return '.' if the gene value is NA. 

I also removed the print statements from the add_omim and add_clingen functions to clean up the log file. 