### PR TITLE
Add DPLM internal allele frequencies

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -50,6 +50,7 @@ annotation:
     gnomad_SV: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/gnomAD/v4.1/SV/gnomad.v4.1.sv.sites.processed.bed"
     dgv: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/DGV/DGV.GS.hg38.tsv"
     1000G_SV: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/1000G/DRAGEN_4_4_7_SV/1000G.1000G_SV_database_AF.bed"
+    GSO_SV: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/GSO_noiseDB/BEDs/GSO_noiseDB.all.sorted.bed"
   vep:
     dir: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake/499f2ad2/share/ensembl-vep-115.2-0/"
     dir_cache: "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/vep"

--- a/docs/variant_report_docs/DRAGEN_SV_CNV_report.md
+++ b/docs/variant_report_docs/DRAGEN_SV_CNV_report.md
@@ -57,6 +57,7 @@ The 1000 Genomes SV database used in report generation was created from [DRAGEN 
   - `gnomad_maxAF < 0.01`
   - `DGV_maxAF < 0.01`
   - `1000G_maxAF < 0.01`
+  - `GSO_maxAF < 0.01`
 
 For analysis, we recommend considering any exon-overlapping SVs or CNVs seen in the proband:
 
@@ -135,6 +136,13 @@ The SV and CNV reports share most columns. Columns that are SV-only or CNV-only 
 | `1000G_SV` | Coordinates/type of matching 1000 Genomes SV(s), where matching is determined using the report’s SVTYPE-specific comparison logic | 1000 Genomes SV database | DEL:10:103293394-103294434 |
 | `1000G_maxAF` | Maximum allele frequency among matching 1000 Genomes SV(s) | 1000 Genomes SV database | 0.15 |
 | `1000G_nhomalt_max` | Maximum homozygous alternate count among matching 1000 Genomes SV(s) | 1000 Genomes SV database | 254 |
+| `GSO_AF` | Allele frequency in GSO DRAGEN genomes (n=7,857). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 0.000636| 
+| `GSO_AC` | Allele count in GSO DRAGEN genomes (n=7,857). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 10 | 
+| `GSO_hemi` | Number of hemizygotes in GSO DRAGEN genomes (n=7,857). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 0 | 
+| `GSO_nhomalt` | Number of homozygotes in GSO DRAGEN genomes (n=7,857). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 4 | 
+| `GSO_SV` | Coordinates/type of matching GSO SV(s), where matching is determined using the report’s SVTYPE-specific comparison logic | DPLM 2026-04-06 | INS:10:100315123-100315126 | 
+| `GSO_maxAF` | Maximum allele frequency among matching GSO SV(s) | DPLM 2026-04-06 | 0.000636 | 
+| `GSO_nhomalt_max` | Maximum homozygous alternate count of matching GSO SV(s) | DPLM 2026-04-06 | 4 | 
 | `ExAC_delZ` | Positive delZ\_ExAC (Z score) from ExAC indicate gene intolerance to deletion | AnnotSV | 0.018797621 |
 | `ExAC_dupZ` | Positive dupZ\_ExAC (Z score) from ExAC indicate gene intolerance to duplication | AnnotSV | \-1.900013288 |
 | `ExAC_cnvZ` | Positive cnvZ\_ExAC (Z score) from ExAC indicate gene intolerance to CNV | AnnotSV | \-1.383777638 |

--- a/docs/variant_report_docs/DRAGEN_small_variant_report.md
+++ b/docs/variant_report_docs/DRAGEN_small_variant_report.md
@@ -123,6 +123,10 @@ The 1000 Genomes sequence variant database (n=3,202, 602 trios) used to annotate
 | `thousandG_AF` | Allele frequency in 1000 Genomes DRAGEN v4.4 genomes (n=3,202, 602 trios) | [1000 Genomes](https://registry.opendata.aws/ilmn-dragen-1kgp/) | 0.0002 |
 | `thousandG_AC` | Allele count in 1000 Genomes DRAGEN v4.4 genomes (n=3,202, 602 trios) | [1000 Genomes](https://registry.opendata.aws/ilmn-dragen-1kgp/) | 2 |
 | `thousandG_nhomalt` | Homozygous alternate count in 1000 Genomes DRAGEN v4.4 genomes (n=3,202, 602 trios) | [1000 Genomes](https://registry.opendata.aws/ilmn-dragen-1kgp/) | 0 |
+| `GSO_AF` | Allele frequency in GSO DRAGEN genomes (n=8,439). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 0.00225099991076 | 
+| `GSO_AC` | Allele count in GSO DRAGEN genomes (n=8,439). NB: this resource includes both affected probands and parents.| DPLM 2026-04-06 | 38 | 
+| `GSO_nhomalt` | Number of homozygotes in GSO DRAGEN genomes (n=8,439). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 1 | 
+| `GSO_hemi` | Number of hemizygotes in GSO DRAGEN genomes (n=8,439). NB: this resource includes both affected probands and parents. | DPLM 2026-04-06 | 0 | 
 | `Ensembl_transcript_id` | Most severely affected transcript | VEP | ENST00000374632 |
 | `rsIDs` | Variant IDs (dbSNP) | VEP | rs28936395 |
 | `AA_position` | Amino-acid position for most severely-affected transcript | VEP | 679/987 |

--- a/resources/vcfanno/vcfanno.conf
+++ b/resources/vcfanno/vcfanno.conf
@@ -18,6 +18,12 @@ names=["thousandG_AC", "thousandG_AF", "thousandG_nhomalt"]
 ops=["self","self","self"]
 
 [[annotation]]
+file="SK-CHEO_WGS_historic_snv_hg38_06APR2026_fixed.sort.header.rmTEN.vcf.gz"
+fields=["AC", "Hom", "Hemi",  "AF"]
+names=["GSO_AC", "GSO_nhomalt", "GSO_hemi", "GSO_AF"]
+ops=["self","self","self","self"]
+
+[[annotation]]
 file="dbsnp-151.vcf.gz"
 fields=["ID"]
 names=["rs_ids"]

--- a/workflow/rules/cnvreport.smk
+++ b/workflow/rules/cnvreport.smk
@@ -50,7 +50,8 @@ rule cnv_report:
         ensembl = config["annotation"]["general"]["ensembl"],
         clingen_path = config["annotation"]["general"]["clingen_path"],
         samples = config["run"]["samples"],
-        thousandg = config["annotation"]["sv_report"]["1000G_SV"]
+        thousandg = config["annotation"]["sv_report"]["1000G_SV"],
+        GSO_SV = config["annotation"]["sv_report"]["GSO_SV"]
     conda:
         "../envs/str_sv.yaml"
     shell:
@@ -72,6 +73,7 @@ rule cnv_report:
                         -clingen_disease {params.clingen_path}/ClinGen_tableExport_202310.csv \
                         -clingen_regions {params.clingen_path}/ClinGen_region_curation_list_GRCh38.tsv \
                         -thousandg {params.thousandg} \
+                        -GSO_SV {params.GSO_SV} \
                         -samples {params.samples}) > {log} 2>&1
 
             else
@@ -91,6 +93,7 @@ rule cnv_report:
                     -clingen_disease {params.clingen_path}/ClinGen_tableExport_202310.csv \
                     -clingen_regions {params.clingen_path}/ClinGen_region_curation_list_GRCh38.tsv \
                     -thousandg {params.thousandg} \
+                    -GSO_SV {params.GSO_SV} \
                     -samples {params.samples}) > {log} 2>&1
             fi
         """

--- a/workflow/rules/svreport.smk
+++ b/workflow/rules/svreport.smk
@@ -73,7 +73,8 @@ rule sv_report:
         ensembl = config["annotation"]["general"]["ensembl"],
         clingen_path = config["annotation"]["general"]["clingen_path"],
         samples = config["run"]["samples"],
-        thousandg = config["annotation"]["sv_report"]["1000G_SV"]
+        thousandg = config["annotation"]["sv_report"]["1000G_SV"],
+        GSO_SV = config["annotation"]["sv_report"]["GSO_SV"]
     conda:
         "../envs/str_sv.yaml"
     shell:
@@ -95,6 +96,7 @@ rule sv_report:
                         -clingen_disease {params.clingen_path}/ClinGen_tableExport_202310.csv \
                         -clingen_regions {params.clingen_path}/ClinGen_region_curation_list_GRCh38.tsv \
                         -thousandg {params.thousandg} \
+                        -GSO_SV {params.GSO_SV} \
                         -samples {params.samples}) > {log} 2>&1
             else
                 (python3 {params.cphi_dragen}/workflow/scripts/annotate_SVs.py \
@@ -113,6 +115,7 @@ rule sv_report:
                     -clingen_disease {params.clingen_path}/ClinGen_tableExport_202310.csv \
                     -clingen_regions {params.clingen_path}/ClinGen_region_curation_list_GRCh38.tsv \
                     -thousandg {params.thousandg} \
+                    -GSO_SV {params.GSO_SV} \
                     -samples {params.samples}) > {log} 2>&1
             fi
         """

--- a/workflow/scripts/annotate_SVs.py
+++ b/workflow/scripts/annotate_SVs.py
@@ -950,6 +950,7 @@ def main(
     gnomad,
     dgv,
     thousandg,
+    GSO_SV,
     ensembl,
     repeats,
     clingen_HI,
@@ -1079,6 +1080,11 @@ def main(
     thousandg_cols = ["1000G_AF", "1000G_AC", "1000G_nhomalt"]
     df_merge = annotate_pop_svs(df_merge, thousandg, thousandg_cols, variant_type)
 
+    # add GSO SVs
+    print("Adding GSO SV frequencies")
+    GSO_SV_cols = ["GSO_AF", "GSO_AC", "GSO_hemi", "GSO_nhomalt"]
+    df_merge = annotate_pop_svs(df_merge, GSO_SV, GSO_SV_cols, variant_type)
+
     # add exon counts
     df_merge = get_exon_counts(df_merge, exon_bed)
 
@@ -1183,6 +1189,7 @@ def main(
         + gnomad_cols
         + dgv_cols
         + thousandg_cols
+        + GSO_SV_cols
         + [
             "ExAC_delZ",
             "ExAC_dupZ",
@@ -1261,6 +1268,12 @@ if __name__ == "__main__":
         required=True, 
         help="1000G SV in bed format"
         )
+    parser.add_argument(
+        "-GSO_SV",
+        type=str,
+        required=True,
+        help="GSO SVs in bed format"
+    )
     parser.add_argument(
         "-ensembl",
         help="Ensembl GTF subset CSV file",
@@ -1355,6 +1368,7 @@ if __name__ == "__main__":
         args.gnomad,
         args.dgv,
         args.thousandg,
+        args.GSO_SV,
         args.ensembl,
         args.repeats,
         clingen_HI,

--- a/workflow/scripts/cre/cre.gemini2txt.vcf2db.sh
+++ b/workflow/scripts/cre/cre.gemini2txt.vcf2db.sh
@@ -88,6 +88,10 @@ sQuery="select \
         thousandG_ac as thousandG_AC,\
         thousandG_af as thousandG_AF,\
         thousandG_nhomalt as thousandG_nhomalt,\
+        GSO_AC as GSO_AC,\
+        GSO_nhomalt as GSO_nhomalt,\
+        GSO_hemi as GSO_hemi,\
+        GSO_AF as GSO_AF,\
         sift_score as Sift_score,\
         polyphen_score as Polyphen_score,\
         cadd_phred as Cadd_score,\

--- a/workflow/scripts/cre/cre.vcf2db.R
+++ b/workflow/scripts/cre/cre.vcf2db.R
@@ -476,7 +476,7 @@ create_report <- function(family, samples, type){
     # Column 57: ENH_cellline_tissue
 
     # replace -1 with 0
-    for (field in c("Trio_coverage", "Gnomad_af", "Gnomad_af_grpmax", "Gnomad_fafmax_faf95_max", "Regeneron_exome_AF", "Regeneron_exome_AC", "thousandG_AF", "thousandG_AC", "thousandG_nhomalt")){
+    for (field in c("Trio_coverage", "Gnomad_af", "Gnomad_af_grpmax", "Gnomad_fafmax_faf95_max", "Regeneron_exome_AF", "Regeneron_exome_AC", "thousandG_AF", "thousandG_AC", "thousandG_nhomalt", "GSO_AC", "GSO_nhomalt", "GSO_hemi", "GSO_AF")){
         variants[,field] <- with(variants, gsub("-1", "0", get(field), fixed = T))
         variants[,field] <- with(variants, gsub("None", "0", get(field), fixed = T))
     }
@@ -520,6 +520,7 @@ select_and_write2 <- function(variants, samples, prefix, type)
                             "Gnomad_af_grpmax", "Gnomad_af", "Gnomad_ac", "Gnomad_hom", "Gnomad_male_ac","Gnomad_fafmax_faf95_max", "Gnomad_filter",
                             "Regeneron_exome_AF", "Regeneron_exome_AC",
                             "thousandG_AF", "thousandG_AC", "thousandG_nhomalt",
+                            "GSO_AF", "GSO_AC", "GSO_nhomalt", "GSO_hemi",
                             "Ensembl_transcript_id", "rsIDs"),
                             protein_cols,
                             c("Gnomad_oe_lof_score", "Gnomad_oe_ci_lower","Gnomad_oe_ci_upper","Gnomad_oe_mis_score", "Gnomad_mis_z_score","Gnomad_pLI_score","Gnomad_pnull_score","Gnomad_prec_score"),


### PR DESCRIPTION
This PR adds DPLM internal allele frequencies and counts for small variants, SVs, and CNVs. 
Note that the internal database does not include BNDs. 

SV README and BED file generation scripts are located at `/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/GSO_noiseDB/`

Small variant README is at `/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/SK-CHEO_WGS_historic_snv_hg38_06APR2026_README`
`