### PR TITLE
Pass reference build to peddy

### DIFF
--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -43,6 +43,7 @@ rule peddy:
         peddy \
           --prefix ./qc/peddy/{wildcards.family} \
           --plot \
+          --sites hg38 \
           {input.vcf} \
           {input.ped} \
           2>&1 | tee {log}


### PR DESCRIPTION
Peddy assumes hg37 by default. Pass hg38. 