### PR TITLE
Fix High Impact Score Handling 

### DIFF
--- a/workflow/scripts/cre/cre.vcf2db.R
+++ b/workflow/scripts/cre/cre.vcf2db.R
@@ -202,11 +202,13 @@ create_report <- function(family, samples, type){
     #SpliceAI_score >= 0.5 or Cadd_score >= 10 (or Cadd_score is missing; not all indels are scored)
     if (type == 'wgs.high.impact'){
         print("Selecting high impact variants")
+        # Convert Cadd_score, SpliceAI_score, and promoterAD_score to numeric, keeping NA for "None" values
         variants$SpliceAI_score_num <- as.numeric(variants$SpliceAI_score)
         variants$Cadd_score_num <- as.numeric(variants$Cadd_score)
         variants$promoterAI_score_num <- as.numeric(variants$promoterAI_score_parsed)
-
+        # Filter based on SpliceAI_score or Cadd_score conditions
         variants <- variants[variants$SpliceAI_score_num >= 0.2 | variants$Cadd_score == "None" | variants$Cadd_score_num >= 10 | variants$promoterAI_score_num >= 0.1,]
+        # Remove the temporary numeric column
         variants$SpliceAI_score_num <- NULL
         variants$Cadd_score_num <- NULL
         variants$promoterAI_score_num <- NULL

--- a/workflow/scripts/cre/cre.vcf2db.R
+++ b/workflow/scripts/cre/cre.vcf2db.R
@@ -202,12 +202,14 @@ create_report <- function(family, samples, type){
     #SpliceAI_score >= 0.5 or Cadd_score >= 10 (or Cadd_score is missing; not all indels are scored)
     if (type == 'wgs.high.impact'){
         print("Selecting high impact variants")
-        # Convert Cadd_score to numeric, keeping NA for "None" values
+        variants$SpliceAI_score_num <- as.numeric(variants$SpliceAI_score)
         variants$Cadd_score_num <- as.numeric(variants$Cadd_score)
-        # Filter based on SpliceAI_score or Cadd_score conditions
-        variants <- variants[variants$SpliceAI_score >= 0.2 | variants$Cadd_score == "None" | variants$Cadd_score_num >= 10 | variants$promoterAI_score_parsed >= 0.1,]
-        # Remove the temporary numeric column
+        variants$promoterAI_score_num <- as.numeric(variants$promoterAI_score_parsed)
+
+        variants <- variants[variants$SpliceAI_score_num >= 0.2 | variants$Cadd_score == "None" | variants$Cadd_score_num >= 10 | variants$promoterAI_score_num >= 0.1,]
+        variants$SpliceAI_score_num <- NULL
         variants$Cadd_score_num <- NULL
+        variants$promoterAI_score_num <- NULL
     }
 
      # count number of noncoding scores that predict an impact


### PR DESCRIPTION
This PR fixes an error in the CRE high impact filtering logic. Specifically, the `SpliceAD_score` and `promoterAI_score` were not being coerced into being numeric causing variants to be retained which should have been. The coercion now happens 

For example, `chr11:48324469:A:G` had a CADD score of `1.469`, a SpliceAI score of `0`, and a promoterAI score of `0.0005`. Since all three values are below the required thresholds, this variant should not have been retained, but it was previously included due to the score coercion issue.
