### PR TITLE
Remove intermediate files

### DIFF
--- a/workflow/rules/annotate_STRs.smk
+++ b/workflow/rules/annotate_STRs.smk
@@ -1,6 +1,6 @@
 rule repeat_VCF_to_df:
     input: config["run"]["samples"]
-    output: "STRs/{family}.repeats.tsv"
+    output: temp("STRs/{family}.repeats.tsv")
     params:
         cphi_dragen_anno = config["tools"]["cphi-dragen-anno"]
     log: "logs/STRs/{family}.repeats.log"

--- a/workflow/rules/annotate_mt_var.smk
+++ b/workflow/rules/annotate_mt_var.smk
@@ -30,8 +30,8 @@ rule mity_report:
     input:
         "mitochondrial_variants/{family}.mt.normalise.decompose.vcf.gz"
     output:
-        "mitochondrial_variants/{family}.mity.annotated.vcf.gz",
-        "mitochondrial_variants/{family}.mity.report.xlsx"
+        temp("mitochondrial_variants/{family}.mity.annotated.vcf.gz"),
+        temp("mitochondrial_variants/{family}.mity.report.xlsx")
     params:
         outdir="mitochondrial_variants/",
         tool=config["tools"]["mity"],

--- a/workflow/rules/annotate_small_var.smk
+++ b/workflow/rules/annotate_small_var.smk
@@ -14,7 +14,7 @@ rule input_prep:
     params:
         outdir="filtered"
     output:
-        "filtered/{family}.vcf.gz"
+        temp("filtered/{family}.vcf.gz")
     wildcard_constraints:
         family = "(?!.*panel|.*coding|.*denovo).*"
     log:
@@ -117,7 +117,7 @@ rule vcf2db:
     input:
         "annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.vcf.gz",
     output:
-         db="annotated/{p}/{family}-gemini.db",
+         db=temp("annotated/{p}/{family}-gemini.db"),
     log:
         "logs/vcf2db/{family}.vcf2db.{p}.log"
     threads: 1
@@ -168,7 +168,8 @@ rule allsnvreport:
          ref=config["ref"]["genome"]
     shell:
          '''
-         (mkdir -p {output}
+         (set -eou pipefail;
+         mkdir -p {output}
          cd {output}
          ln -s ../../../{input.db} {family}-ensemble.db
          #bgzip ../../../{input.vcf} -c > {family}-gatk-haplotype-annotated-decomposed.vcf.gz

--- a/workflow/rules/cnvreport.smk
+++ b/workflow/rules/cnvreport.smk
@@ -1,7 +1,7 @@
 rule cnv_snpeff:
     input: get_cnv_vcf
     output:
-        vcf = "cnv/{family}.cnv.snpeff.vcf",
+        vcf = temp("cnv/{family}.cnv.snpeff.vcf"),
     log:
         "logs/cnv/{family}.snpeff.log"
     params:
@@ -15,7 +15,7 @@ rule cnv_snpeff:
 rule cnv_annotsv:
     input: get_cnv_vcf
     output:
-        annotsv_annotated =  "cnv/{family}.AnnotSV.tsv",
+        annotsv_annotated =  temp("cnv/{family}.AnnotSV.tsv"),
         annotsv_unannotated =  temp("cnv/{family}.AnnotSV.unannotated.tsv")
     log: "logs/cnv/{family}.annotsv.log"
     params:
@@ -37,7 +37,7 @@ rule cnv_report:
     input: 
         snpeff = "cnv/{family}.cnv.snpeff.vcf",
         annotsv = "cnv/{family}.AnnotSV.tsv"
-    output: "cnv/{family}.cnv.csv"
+    output: temp("cnv/{family}.cnv.csv")
     log: "logs/cnv/{family}.cnv.report.log"
     params:
         cphi_dragen = config["tools"]["cphi-dragen-anno"],

--- a/workflow/rules/compound_hets.smk
+++ b/workflow/rules/compound_hets.smk
@@ -29,7 +29,7 @@ rule get_small_variants_for_CH:
     input:
         gemini_db="annotated/coding/{family}-gemini.db"
     output:
-        variants="small_variants/{family}.{severity}.impact.variants.tsv",
+        variants=temp("small_variants/{family}.{severity}.impact.variants.tsv"),
     params:
         severity="{severity}",
         crg2_pacbio = config["tools"]["crg2_pacbio"],
@@ -47,7 +47,7 @@ rule get_VCF_sample_order:
     input:
         vcf="annotated/coding/vcfanno/{family}.coding.vep.vcfanno.vcf.gz",
     output:
-        sample_order="small_variants/{family}.sample.order.txt",
+        sample_order=temp("small_variants/{family}.sample.order.txt"),
     log:
         "logs/compound_hets/{family}.get.VCF.sample.order.log",
     conda:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -179,7 +179,7 @@ rule multiqc:
         dragen_mapping="qc/multiqc_custom/{family}/dragen_mapping_mqc.tsv",
         dragen_qc_summary="qc/multiqc_custom/{family}/dragen_qc_summary_mqc.tsv",
     output:
-        report="qc/multiqc/{family}.multiqc_report.html"
+        report=temp("qc/multiqc/{family}.multiqc_report.html")
     log:
         "logs/qc/multiqc/{family}.multiqc.log"
     conda:

--- a/workflow/rules/svreport.smk
+++ b/workflow/rules/svreport.smk
@@ -2,7 +2,7 @@ rule bnd_to_inv:
     input:
         vcf = get_sv_vcf
     output:
-        vcf = "sv/{family}.sv.bnd_to_inv.vcf"
+        vcf = temp("sv/{family}.sv.bnd_to_inv.vcf")
     log:
         "logs/sv/{family}.bnd_to_inv.log"
     params:
@@ -28,7 +28,7 @@ rule snpeff:
     input:
         "sv/{family}.sv.bnd_to_inv.vcf"
     output:
-        vcf = "sv/{family}.sv.snpeff.vcf",
+        vcf = temp("sv/{family}.sv.snpeff.vcf"),
     log:
         "logs/sv/{family}.snpeff.log"
     params:
@@ -43,7 +43,7 @@ rule annotsv:
     input:
         "sv/{family}.sv.bnd_to_inv.vcf"
     output:
-        annotsv_annotated =  "sv/{family}.AnnotSV.tsv",
+        annotsv_annotated =  temp("sv/{family}.AnnotSV.tsv"),
         annotsv_unannotated =  temp("sv/{family}.AnnotSV.unannotated.tsv")
     log: "logs/sv/{family}.annotsv.log"
     params:
@@ -65,7 +65,7 @@ rule sv_report:
     input: 
         snpeff = "sv/{family}.sv.snpeff.vcf",
         annotsv = "sv/{family}.AnnotSV.tsv"
-    output: "sv/{family}.sv.csv"
+    output: temp("sv/{family}.sv.csv")
     log: "logs/sv/{family}.sv.report.log"
     params:
         cphi_dragen = config["tools"]["cphi-dragen-anno"],


### PR DESCRIPTION
Mark intermediate files as temporary so they are automatically removed by Snakemake. This will save space, and clean up the run directories.