### PR TITLE
Add QC check table to multiQC report

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,3 +67,9 @@ annotation:
 qc:
   svdp: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/QC/1000g.phase3.100k.b38.vcf.gz.dat"
   refcache: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/refcache/hg38"
+  pass_fail_thresholds:
+    min_mean_coverage: 20
+    max_freemix: 0.02
+    unrelated_max_rel: 0.2
+    firstdeg_min_rel: 0.4
+    firstdeg_max_rel: 0.6

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -70,6 +70,6 @@ qc:
   pass_fail_thresholds:
     min_mean_coverage: 20
     max_freemix: 0.02
-    unrelated_max_rel: 0.2
+    unrelated_max_rel: 0.02
     firstdeg_min_rel: 0.4
     firstdeg_max_rel: 0.6

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -168,6 +168,29 @@ rule dragenmetrics:
     script:
         "../scripts/dragen_metrics_to_mqc.py"
 
+rule qc_pass_fail:
+    input:
+        samples_tsv=config["run"]["samples"],
+        dragen_qc_summary="qc/multiqc_custom/{family}/dragen_qc_summary_mqc.tsv",
+        selfsm=expand("qc/verifybam/{family}/{sample}.selfSM", family=family, sample=samples.index),
+        sex_check="qc/peddy/{family}.sex_check.csv",
+        ped_check="qc/peddy/{family}.ped_check.csv"
+    output:
+        tsv="qc/multiqc_custom/{family}/qc_pass_fail_mqc.tsv"
+    log:
+        "logs/qc/qc_pass_fail/{family}.log"
+    conda:
+        "../envs/annotate.yaml"
+    params:
+        samples=list(samples.index),
+        min_mean_coverage=config["qc"]["pass_fail_thresholds"]["min_mean_coverage"],
+        max_freemix=config["qc"]["pass_fail_thresholds"]["max_freemix"],
+        unrelated_max_rel=config["qc"]["pass_fail_thresholds"]["unrelated_max_rel"],
+        firstdeg_min_rel=config["qc"]["pass_fail_thresholds"]["firstdeg_min_rel"],
+        firstdeg_max_rel=config["qc"]["pass_fail_thresholds"]["firstdeg_max_rel"]
+    script:
+        "../scripts/qc_pass_fail_to_mqc.py"
+
 rule multiqc:
     input:
         peddy_html=f"qc/peddy/{family}.html",
@@ -178,6 +201,7 @@ rule multiqc:
         dragen_duplication="qc/multiqc_custom/{family}/dragen_duplication_mqc.tsv",
         dragen_mapping="qc/multiqc_custom/{family}/dragen_mapping_mqc.tsv",
         dragen_qc_summary="qc/multiqc_custom/{family}/dragen_qc_summary_mqc.tsv",
+        qc_pass_fail="qc/multiqc_custom/{family}/qc_pass_fail_mqc.tsv",
     output:
         report=temp("qc/multiqc/{family}.multiqc_report.html")
     log:

--- a/workflow/scripts/multiqc_config.yaml
+++ b/workflow/scripts/multiqc_config.yaml
@@ -19,7 +19,19 @@ sp:
     fn: "dragen_mapping_mqc.tsv"
   dragen_qc_summary:
     fn: "dragen_qc_summary_mqc.tsv"
+  qc_pass_fail:
+    fn: "qc_pass_fail_mqc.tsv"
 custom_data:
+  qc_pass_fail:
+    file_format: tsv
+    section_name: "QC Pass/Fail Summary"
+    description: "Per-sample pass/fail status for key QC checks (True = condition met, NA = not evaluable)."
+    plot_type: table
+    pconfig:
+      id: qc_pass_fail
+      namespace: qc_pass_fail
+      sort_rows: false
+      col1_header: Sample
   peddy_relatedness:
     file_format: tsv
     section_name: "Peddy Relatedness"
@@ -151,6 +163,8 @@ custom_data:
         format: "{:.2f}"
 plots_force_interactive: true
 report_section_order:
+  qc_pass_fail:
+    order: 2000
   peddy_relatedness:
     order: 1000
 table_cond_formatting_colours:
@@ -163,6 +177,11 @@ table_cond_formatting_colours:
   - male: "#5bc0de"
   - female: "#d9534f"
 table_cond_formatting_rules:
+  qc_pass_fail:
+    pass:
+      - s_eq: "True"
+    fail:
+      - s_eq: "False"
   peddy_relatedness-Peddy_Relatedness:
     ped_low:
       - lt: 0.25

--- a/workflow/scripts/qc_pass_fail_to_mqc.py
+++ b/workflow/scripts/qc_pass_fail_to_mqc.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pandas as pd
+
+samples_tsv = snakemake.input.samples_tsv
+dragen_qc_summary = snakemake.input.dragen_qc_summary
+selfsm_files = snakemake.input.selfsm
+sex_check = snakemake.input.sex_check
+ped_check = snakemake.input.ped_check
+
+out_tsv = snakemake.output.tsv
+
+samples = list(snakemake.params.samples)
+min_cov = float(snakemake.params.min_mean_coverage)
+max_freemix = float(snakemake.params.max_freemix)
+unrelated_max = float(snakemake.params.unrelated_max_rel)
+firstdeg_min = float(snakemake.params.firstdeg_min_rel)
+firstdeg_max = float(snakemake.params.firstdeg_max_rel)
+
+
+def to_bool_str(val):
+    if val is None or (isinstance(val, float) and np.isnan(val)):
+        return "NA"
+    return "True" if val else "False"
+
+
+# 1. Mean coverage >= min_cov (DRAGEN average autosomal coverage over genome)
+cov_summary = pd.read_csv(dragen_qc_summary, sep="\t", dtype=str)
+cov_map = {}
+for _, row in cov_summary.iterrows():
+    try:
+        cov_map[row["Sample"]] = float(row["Avg_autosomal_cov"])
+    except (ValueError, TypeError, KeyError):
+        cov_map[row["Sample"]] = np.nan
+
+coverage_pass = {}
+for sample in samples:
+    cov = cov_map.get(sample, np.nan)
+    coverage_pass[sample] = np.nan if pd.isna(cov) else (cov >= min_cov)
+
+
+# 2. Contamination (VerifyBamID FREEMIX) < max_freemix (FREEMIX is a fraction 0-1)
+freemix_pass = {sample: np.nan for sample in samples}
+for sample, selfsm in zip(samples, selfsm_files):
+    df = pd.read_csv(selfsm, sep="\t")
+    freemix_cols = [c for c in df.columns if c.strip().upper() == "FREEMIX"]
+    if df.empty or not freemix_cols:
+        continue
+    try:
+        freemix = float(df.iloc[0][freemix_cols[0]])
+    except (ValueError, TypeError):
+        continue
+    freemix_pass[sample] = freemix < max_freemix
+
+
+# 3. Derived sex matches pedigree sex (peddy sex_check.csv error == False)
+sex_pass = {sample: np.nan for sample in samples}
+sex_df = pd.read_csv(sex_check)
+if {"sample_id", "error"}.issubset(sex_df.columns):
+    for _, row in sex_df.iterrows():
+        sid = str(row["sample_id"])
+        if sid not in sex_pass:
+            continue
+        err = str(row["error"]).strip().lower()
+        if err in ("true", "false"):
+            sex_pass[sid] = err == "false"
+
+
+# 4. Relatedness consistent with pedigree (peddy ped_check.csv, pairwise -> per-sample)
+# See https://help.connected.illumina.com/emedgene/emedgene-analyze-manual/reviewing_a_case/lab_tab/pedigree-section
+# Unrelated individuals i.e parents (if not consanguineous) should have a relatedness percentage < 0.2. 
+# Parent-child and sibling-sibling should have relatedness between 40 - 60.
+# A sample passes only if every pair it participates in is consistent.
+rel_checks = {sample: [] for sample in samples}
+ped_df = pd.read_csv(ped_check)
+if {"sample_a", "sample_b", "rel", "pedigree_relatedness"}.issubset(ped_df.columns):
+    for _, row in ped_df.iterrows():
+        sample_a = str(row["sample_a"])
+        sample_b = str(row["sample_b"])
+        try:
+            rel = float(row["rel"])
+            expected = float(row["pedigree_relatedness"])
+        except (ValueError, TypeError):
+            continue
+
+        if expected == 0:
+            consistent = rel < unrelated_max
+        elif expected == 0.5:
+            consistent = firstdeg_min <= rel <= firstdeg_max
+        else:
+            consistent = abs(rel - expected) <= 0.1
+
+        for sample in (sample_a, sample_b):
+            if sample in rel_checks:
+                rel_checks[sample].append(consistent)
+
+relatedness_pass = {}
+for sample in samples:
+    checks = rel_checks[sample]
+    relatedness_pass[sample] = np.nan if not checks else all(checks)
+
+
+checks = [
+    ("Mean coverage >= {:g}X".format(min_cov), coverage_pass),
+    ("Contamination (VerifyBamID FREEMIX) < {:g}%".format(max_freemix * 100), freemix_pass),
+    ("Correct sex", sex_pass),
+    ("Relatedness consistent with pedigree", relatedness_pass),
+]
+
+out_df = pd.DataFrame({"Sample": samples})
+for name, result in checks:
+    out_df[name] = [to_bool_str(result.get(sample, np.nan)) for sample in samples]
+
+out_df.to_csv(out_tsv, sep="\t", index=False)


### PR DESCRIPTION
This PR adds a new table, QC Pass/Fail Summary, to the MultiQC report. The table serves as a quick check for the folllowing:

1. Is mean coverage >=20X?
2. Is contamination (VerifyBAMID FREEMIX) < 2%?
3. Is the sex derived by peddy from the sequencing data consistent with the sex defined in the pedigree?
4.  Is the relatedness metric between samples consistent with the relationships described in the pedigree? Unrelated individuals i.e parents should have a relatedness percentage < 0.2%. Parent-child and sibling-sibling should have relatedness between 40 - 60%. For other relationships, the absolute difference between the expected relatedness predicted by peddy and the actual relatedness should be less than 10%. I based this off of [Illumina's recommendations](https://help.connected.illumina.com/emedgene/emedgene-analyze-manual/reviewing_a_case/lab_tab/pedigree-section).


See example report at `/hpf/largeprojects/tgnode/sandbox/mcouse_analysis/scripts/pipeline_dev/DRAGEN_QC/GD166/reports/FAM-001438.multiqc_report.html`.