### PR TITLE
Bug fix

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,8 +1,11 @@
 from snakemake.utils import min_version
 import pandas as pd
+from os.path import expanduser
 
 ##### set minimum snakemake version #####
 min_version("9.16.2")
+
+crg2_pacbio = expanduser(config["tools"]["crg2_pacbio"])
 
 def get_children_ids(ped_file):
     pedigree = pd.read_csv(ped_file, sep=None, header=None, 

--- a/workflow/rules/annotate_mt_var.smk
+++ b/workflow/rules/annotate_mt_var.smk
@@ -1,6 +1,4 @@
 
-crg2_pacbio = config["tools"]["crg2_pacbio"]
-
 rule extract_mt_variants:
     input:
         vcf=get_small_variant_vcf

--- a/workflow/rules/annotate_small_var.smk
+++ b/workflow/rules/annotate_small_var.smk
@@ -41,7 +41,7 @@ rule pass:
     input:
         "{prefix}.{ext}"
     output:
-        temp("{prefix}.pass.{ext,(vcf|vcf\.gz)}")
+        temp(r"{prefix}.pass.{ext,(vcf|vcf\.gz)}")
     threads: 6
     resources:
         mem=lambda wildcards, threads: threads * 2


### PR DESCRIPTION
bug-fix 1: Sakemake/python does not automatically expand "~" when a home directory is specified for crg2-pacbio repo in the config file and throws a filenotfound error for the `generate_mt_report` rule. The fix expands the home directory path in the Snakefile and passes the resolved absolute path as a parameter to `generate_mt_report` rule

bug-fix 2: Fixed the following warning by adding an r string to the output of rule `pass`.
```
/home/ajain/CPHI-DRAGEN-anno/workflow/rules/annotate_small_var.smk:94: SyntaxWarning: invalid escape sequence '\.'
  "logs/bcftools/{family}.add.PS.field.{p}.log"
```