### PR TITLE
Add OMIM and HGVS Columns to SF Reports

### DIFF
--- a/docs/pipeline_docs/acmg_secondary_findings_gene_annotation.md
+++ b/docs/pipeline_docs/acmg_secondary_findings_gene_annotation.md
@@ -46,6 +46,10 @@ Combined ACMG SF report columns
 | `SVTYPE` | Structural variant type for SV/CNV records. SNV records receive `.` | `DEL` |
 | `GENE`| Gene name or gene symbols associated with the variant | `BRCA1` |
 | `ACMG_SF_GENE` | ACMG SF gene symbol or symbols matched for this variant. Multiple matches are separated by `;`. | `BRCA1` |
+| `OMIM_PHENOTYPE` | OMIM phenotype annotation from small variant, SV, or CNV report. | `Breast-ovarian cancer, familial, 1` |
+| `ACMG_SF_GENE_PHENOTYPE` | Phenotype(s) for the matched gene(s) from the configured ACMG SF list. Multiple unique values are separated by `;`. | `Hereditary breast and ovarian cancer` |
+| `ACMG_SF_GENE_INHERITANCE` | Inheritance mode(s) for the matched gene(s) from the configured ACMG SF list. Multiple unique values are separated by `;`. | `AD` |
+| `REFSEQ_CHANGE` | Value copied from `Refseq_change` for coding variants. SV and CNV records receive `.`. | `NM_007294.4:c.5266dup:p.Gln1756ProfsTer74` |
 | `CONSEQUENCE` | Variant consequence | `missense_variant` |
 | `FAMILY` | Family or project identifier | `FAM-001267` |
 | `SAMPLE_ZYGOSITIES` | Collapsed zygosity values across available sample zygosity columns. Values are formatted as `sample=value` and separated by `;`. | `CA1C_000001_EXP_0001=Het;CA1C_000002_EXP_0001=Hom` |

--- a/workflow/rules/acmg_sf.smk
+++ b/workflow/rules/acmg_sf.smk
@@ -32,6 +32,7 @@ rule create_acmg_sf_report:
             family=wildcards.family,
             input_report_type=acmg_sf_input_report_type,
         ),
+        acmg_sf_list=config["annotation"]["general"]["acmg_sf_list"],
     output:
         report="reports/{family}.ACMG.SF.hg38.csv",
     params:

--- a/workflow/scripts/create_acmg_sf_report.py
+++ b/workflow/scripts/create_acmg_sf_report.py
@@ -46,6 +46,32 @@ def per_sample_zygosity_genotype_columns(row, sample_columns):
     return columns
 
 
+def get_acmg_sf_gene_annotations(acmg_gene_string, acmg_sf_list):
+    if pd.isna(acmg_gene_string) or str(acmg_gene_string).strip() in ("", "."):
+        return ".", "."
+
+    genes = []
+    for gene_value in str(acmg_gene_string).split(";"):
+        gene = gene_value.strip()
+        if gene:
+            genes.append(gene)
+
+    # Match the reported gene or genes directly to rows in the ACMG SF list.
+    matches = acmg_sf_list[acmg_sf_list["Gene"].isin(genes)]
+    phenotypes = matches["Phenotype"].dropna().astype(str).str.strip()
+    phenotypes = phenotypes[(phenotypes != "") & (phenotypes != ".")]
+    phenotypes = phenotypes.drop_duplicates()
+
+    inheritances = matches["Inheritance"].dropna().astype(str).str.strip()
+    inheritances = inheritances[(inheritances != "") & (inheritances != ".")]
+    inheritances = inheritances.drop_duplicates()
+
+    return (
+        ";".join(phenotypes) if len(phenotypes) > 0 else ".",
+        ";".join(inheritances) if len(inheritances) > 0 else ".",
+    )
+
+
 def make_variant_key(row, input_report_type):
     if input_report_type in ["wgs.coding.CH", "wgs.high.impact.CH", "wgs.denovo.CH"]:
         return f"{get_value(row, 'Position')}:{get_value(row, 'Ref')}:{get_value(row, 'Alt')}"
@@ -59,7 +85,7 @@ def make_variant_key(row, input_report_type):
 
     return "."
 
-def make_acmg_sf_report_rows(df, family, input_report_type, acmg_col):
+def make_acmg_sf_report_rows(df, family, input_report_type, acmg_col, acmg_sf_list,):
     acmg_matches = df[df[acmg_col] != "."].copy()
     sample_columns = discover_samples(acmg_matches)
     report_rows = []
@@ -76,6 +102,8 @@ def make_acmg_sf_report_rows(df, family, input_report_type, acmg_col):
             clinvar = get_value(row, "Clinvar")
             gnomad_af = get_value(row, "Gnomad_af")
             ucsc_link = get_value(row, "UCSC_Link")
+            # Copy the RefSeq change already present in the coding report.
+            refseq_change = get_value(row, "Refseq_change")
 
         elif input_report_type in ["sv.CH", "cnv.CH"]:
             chrom = str(get_value(row, "CHROM"))
@@ -92,18 +120,31 @@ def make_acmg_sf_report_rows(df, family, input_report_type, acmg_col):
             clinvar = "."
             gnomad_af = get_value(row, "gnomad_GRPMAX_AF")
             ucsc_link = get_value(row, "UCSC_link")
+            # RefSeq changes are not currently reported for SVs and CNVs.
+            refseq_change = "."
 
         else:
             continue
 
+        acmg_sf_gene = get_value(row, acmg_col)
+        acmg_sf_gene_phenotype, acmg_sf_gene_inheritance = (
+            get_acmg_sf_gene_annotations(acmg_sf_gene, acmg_sf_list)
+        )
+
+        # OMIM comes from the annotated input; the ACMG values come from the
+        # secondary-findings gene list loaded above.
         report_row = {
             "POSITION": position,
             "END": end,
             "REF": ref,
             "ALT": alt,
             "SVTYPE": svtype,
+            "REFSEQ_CHANGE": refseq_change,
             "GENE": gene,
-            "ACMG_SF_GENE": get_value(row, acmg_col),
+            "ACMG_SF_GENE": acmg_sf_gene,
+            "OMIM_PHENOTYPE": get_value(row, "omim_phenotype"),
+            "ACMG_SF_GENE_PHENOTYPE": acmg_sf_gene_phenotype,
+            "ACMG_SF_GENE_INHERITANCE": acmg_sf_gene_inheritance,
             "CONSEQUENCE": consequence,
             "FAMILY": family,
             "CLINVAR": clinvar,
@@ -167,7 +208,7 @@ def infer_input_report_type(path):
     raise ValueError(f"Could not infer input report type from path: {path}")
 
 
-def main(family, input_reports, output_csv, acmg_sf_version):
+def main(family, input_reports, output_csv, acmg_sf_version, acmg_sf_tsv):
     logfile = f"logs/report/acmg_sf/{family}.acmg_sf_report.log"
     logging.basicConfig(
         filename=logfile,
@@ -178,6 +219,8 @@ def main(family, input_reports, output_csv, acmg_sf_version):
     )
 
     acmg_col = f"ACMG_SF_v{acmg_sf_version}"
+    acmg_sf_list = pd.read_csv(acmg_sf_tsv, sep="\t", usecols=["Gene", "Phenotype", "Inheritance"],)
+    acmg_sf_list["Gene"] = acmg_sf_list["Gene"].astype("string").str.strip()
     report_parts = []
     flag_inputs = []
 
@@ -194,6 +237,7 @@ def main(family, input_reports, output_csv, acmg_sf_version):
                 family=family,
                 input_report_type=input_report_type,
                 acmg_col=acmg_col,
+                acmg_sf_list=acmg_sf_list,
             )
             if len(rows) > 0:
                 report_parts.append(rows)
@@ -212,6 +256,10 @@ def main(family, input_reports, output_csv, acmg_sf_version):
             "SVTYPE",
             "GENE",
             "ACMG_SF_GENE",
+            "OMIM_PHENOTYPE",
+            "ACMG_SF_GENE_PHENOTYPE",
+            "ACMG_SF_GENE_INHERITANCE",
+            "REFSEQ_CHANGE",
             "CONSEQUENCE",
             "FAMILY",
             "SAMPLE_ZYGOSITY",
@@ -244,5 +292,6 @@ if __name__ == "__main__":
     input_reports = list(snakemake.input.reports)
     output_csv = snakemake.output.report
     acmg_sf_version = snakemake.params.acmg_sf_version
+    acmg_sf_tsv = snakemake.input.acmg_sf_list
 
-    main(family, input_reports, output_csv, acmg_sf_version)
+    main(family, input_reports, output_csv, acmg_sf_version, acmg_sf_tsv)


### PR DESCRIPTION
Adds additional annotation columns to the combined ACMG secondary findings report:

- `OMIM_PHENOTYPE` from the annotated input report
- `ACMG_SF_GENE_PHENOTYPE` from the ACMG SF list
- `ACMG_SF_GENE_INHERITANCE` from the ACMG SF list
- `REFSEQ_CHANGE` from the annotated input small variant reports; `.` for SVs and CNVs

Repeated genes and variants matching multiple ACMG genes retain all phenotypes and inheritance values separated by semicolons.

Example output: `/hpf/largeprojects/ccmbio/students/rkhan/cphi_dragen_runs/260818_sfcols/reports/{family}.ACMG.SF.hg38.csv`